### PR TITLE
add ability to send down the device configuration string. 

### DIFF
--- a/Arduino/AD2SmartThings ArduinoMega Sketch
+++ b/Arduino/AD2SmartThings ArduinoMega Sketch
@@ -150,6 +150,9 @@ void messageCallout(String message)
         Serial.println("Sent Alarm: " + securityCode+cmd);
       }
     }
+    if (code.equals("[CONF]")) {
+      Serial1.println("C" + cmd);
+    }
   }
 }
 void sendUpdate()


### PR DESCRIPTION
Note: this will write to the eeprom of the AD2\* so caution should be used to not excessively do this task or it would eventually damage the EEPROM. This should be preformed only during system setup and configuration NOT every time someone sends a command to the panel.
