### PR TITLE
Update Simulated_Motion_Sensor_Device_Handler

### DIFF
--- a/SmartApp/Simulated_Motion_Sensor_Device_Handler
+++ b/SmartApp/Simulated_Motion_Sensor_Device_Handler
@@ -27,8 +27,8 @@ metadata {
 
 	tiles {
 		standardTile("motion", "device.motion", width: 2, height: 2) {
-			state("inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff", action: "active")
-			state("active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0", action: "inactive")
+			state("inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff" /*, action: "active"*/)
+			state("active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0" /*, action: "inactive"*/)
 		}
 		main "motion"
 		details "motion"


### PR DESCRIPTION
I realized that the action associated to the tiles provided no value and sometimes I had accidentally pressed it causing it to be out of sync with the alarm panel.  As a result I disabled the action.